### PR TITLE
Stop copying levy mailbox on statement emails

### DIFF
--- a/GmailSMTP_Levy_v1.bas
+++ b/GmailSMTP_Levy_v1.bas
@@ -27,8 +27,7 @@ Public Function SendLevyEmail_Outlook(ByVal toList As String, _
 
     With olMail
         .To = toList
-        If Len(ccList) > 0 Then .CC = ccList
-        If Len(bccList) > 0 Then .BCC = bccList
+        ' CC and BCC are intentionally disabled for this mail flow.
         .subject = subject
 
         If Len(htmlBody) > 0 Then

--- a/SendLevyStatements_v3c.bas
+++ b/SendLevyStatements_v3c.bas
@@ -83,7 +83,6 @@ Public Sub SendAllLevyStatements_UsingTemplate_V3c()
                     toList:=emailAddr, _
                     subject:=subj, _
                     htmlBody:=htmlBody, _
-                    bccList:="levy@beraderproperties.com", _
                     attachments:=Array(pdfPath) _
                  )
             


### PR DESCRIPTION
## Summary
- remove the hardcoded levy BCC from statement sends
- disable CC/BCC assignment in the shared Outlook mail helper for this flow

## Testing
- not run (verified by code search and diff only)